### PR TITLE
angler: flag app that is in playstore as presigned

### DIFF
--- a/angler/Android.mk
+++ b/angler/Android.mk
@@ -53,7 +53,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := HotwordEnrollment
 LOCAL_MODULE_OWNER := huawei
 LOCAL_SRC_FILES := proprietary/priv-app/HotwordEnrollment/HotwordEnrollment.apk
-LOCAL_CERTIFICATE := platform
+LOCAL_CERTIFICATE := PRESIGNED
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_CLASS := APPS
 LOCAL_MODULE_SUFFIX := .apk


### PR DESCRIPTION
This prevents signature check failure and certificate mismatch error from the playstore.
